### PR TITLE
Fixed the error about adding the bot as friend.

### DIFF
--- a/SOURCE/ASteambot/Bot.cs
+++ b/SOURCE/ASteambot/Bot.cs
@@ -23,6 +23,8 @@ namespace ASteambot
 {
     public class Bot
     {
+        private readonly DateTime NullDate = new DateTime(1970, 1, 1);
+
         private Database DB;
         private bool renaming;
         private string myUniqueId;
@@ -593,6 +595,9 @@ namespace ASteambot
                 SteamFriends.RemoveFriend(steamID);
                 Friends.Remove(steamID);
             }
+
+            foreach (SteamID neoFriend in newFriends)
+                SteamFriends.AddFriend(neoFriend);
         }
 
         private void OnProfileInfo(SteamFriends.PersonaStateCallback obj)
@@ -609,7 +614,7 @@ namespace ASteambot
             {
                 Program.PrintErrorMessage("FriendID was null ?! -> Bot:593");
             }
-            else if ((DateTime.Now - obj.LastLogOn).TotalDays > 4)
+            else if (obj.LastLogOn != NullDate && (DateTime.Now - obj.LastLogOn).TotalDays > 4)
             {
                 SteamFriends.RemoveFriend(obj.FriendID);
                 Friends.Remove(obj.FriendID);


### PR DESCRIPTION
Please note that there could be a problem where if the bot was offline (i.e. not running) while someone send a friend request, the bot will not accept the friend request because the new friend wasn't removed from its list on boot.
I wasn't able to fix it without breaking something as I don't know how the code works completely.